### PR TITLE
:bug: Fix Dockerfile creation for node

### DIFF
--- a/cli/lib/builder.ts
+++ b/cli/lib/builder.ts
@@ -25,13 +25,13 @@ function makeDockerfileText(packageJson: any, startJson: StartJson)
 
     const dockerfile =
 `# TODO: parameterize node.js version from "engines" in package.json
-FROM mhart/alpine-node:6
+FROM node
 
 WORKDIR /src
 ADD . .
 
 ${exposes}
-CMD ["npm", "install"]
+RUN npm install
 CMD ["node", "${packageJson.main}"]`;
 
     return dockerfile;


### PR DESCRIPTION
@timfpark @hausdorff 
Awesome work! This is a great idea! 👏 

I have some changes following best practice from: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
- Using official node base image 
- install npm packages using `RUN npm install`

Just FYI, the existing Dockerfile failed to build images on platforms like Deis.
